### PR TITLE
test: add MPI test coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,5 +35,10 @@ ruff check . && ruff format --check .    # lint
 
 - PolyChord must be installed separately (build from source)
 - MPI (`mpi4py`) required for full PolySwyft runs; unit tests do not require MPI
+- MPI integration tests (require `mpi4py` + `mpirun`):
+  ```bash
+  mpirun -n 1 pytest tests/test_mpi_integration.py -m integration -v
+  mpirun -n 2 pytest tests/test_mpi_integration.py -m integration -v
+  ```
 - Version is auto-bumped on merge to master via `.github/workflows/version-bump.yml` (conventional commits: `feat:` -> minor, `fix:` -> patch, `BREAKING CHANGE`/`feat!:` -> major)
 - Version lives in both `pyproject.toml` and `polyswyft/__init__.py`

--- a/tests/test_mpi_integration.py
+++ b/tests/test_mpi_integration.py
@@ -1,0 +1,124 @@
+"""Integration tests for MPI code paths — require mpi4py and mpirun.
+
+Run with:
+    mpirun -n 1 pytest tests/test_mpi_integration.py -v
+    mpirun -n 2 pytest tests/test_mpi_integration.py -v
+"""
+
+import logging
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import swyft
+
+MPI = pytest.importorskip("mpi4py.MPI")
+
+from polyswyft.settings import PolySwyftSettings  # noqa: E402
+from polyswyft.utils import resimulate_deadpoints  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+
+def _make_settings(root, num_features=2, num_features_dataset=4):
+    settings = PolySwyftSettings(root=root)
+    settings.num_features = num_features
+    settings.num_features_dataset = num_features_dataset
+    settings.logger = logging.getLogger("mpi_integration_test")
+    settings.use_noise_resampling = False
+    return settings
+
+
+def _make_mock_simulator(settings):
+    """Mock simulator returning real swyft.Sample objects."""
+    d = settings.num_features_dataset
+    rng = np.random.default_rng(42 + MPI.COMM_WORLD.Get_rank())
+    sim = MagicMock()
+
+    def _sample(conditions=None, targets=None):
+        return swyft.Sample(
+            **{
+                settings.targetKey: conditions[settings.targetKey].ravel(),
+                settings.obsKey: rng.standard_normal(d),
+            }
+        )
+
+    sim.sample.side_effect = _sample
+    return sim
+
+
+def _shared_tmpdir():
+    """Create a tmpdir on rank 0 and broadcast the path to all ranks."""
+    comm = MPI.COMM_WORLD
+    if comm.Get_rank() == 0:
+        path = tempfile.mkdtemp(prefix="polyswyft_mpi_test_")
+    else:
+        path = None
+    path = comm.bcast(path, root=0)
+    return path
+
+
+class TestResimulateDeadpointsIntegration:
+    def test_returns_correct_shapes(self):
+        """All ranks get thetas and Ds with correct shapes."""
+        comm = MPI.COMM_WORLD
+        root = _shared_tmpdir()
+        settings = _make_settings(root)
+        n_deadpoints = 20
+        deadpoints = np.random.default_rng(0).standard_normal((n_deadpoints, settings.num_features))
+
+        rd_dir = f"{root}/{settings.child_root}_0"
+        os.makedirs(rd_dir, exist_ok=True)
+        comm.Barrier()
+
+        sim = _make_mock_simulator(settings)
+        thetas, Ds = resimulate_deadpoints(deadpoints, settings, sim, rd=0)
+
+        assert thetas.shape == (n_deadpoints, settings.num_features)
+        assert Ds.shape == (n_deadpoints, settings.num_features_dataset)
+
+    def test_all_ranks_get_same_data(self):
+        """After bcast, all ranks must have identical thetas and Ds."""
+        comm = MPI.COMM_WORLD
+        root = _shared_tmpdir()
+        settings = _make_settings(root)
+        n_deadpoints = 20
+        deadpoints = np.random.default_rng(0).standard_normal((n_deadpoints, settings.num_features))
+
+        rd_dir = f"{root}/{settings.child_root}_0"
+        os.makedirs(rd_dir, exist_ok=True)
+        comm.Barrier()
+
+        sim = _make_mock_simulator(settings)
+        thetas, Ds = resimulate_deadpoints(deadpoints, settings, sim, rd=0)
+
+        # Gather results from all ranks onto rank 0
+        all_thetas = comm.gather(thetas, root=0)
+        all_Ds = comm.gather(Ds, root=0)
+
+        if comm.Get_rank() == 0:
+            for i in range(1, len(all_thetas)):
+                np.testing.assert_array_equal(all_thetas[0], all_thetas[i])
+                np.testing.assert_array_equal(all_Ds[0], all_Ds[i])
+
+    def test_file_only_on_rank_zero(self):
+        """Only rank 0 should create .npy files."""
+        comm = MPI.COMM_WORLD
+        root = _shared_tmpdir()
+        settings = _make_settings(root)
+        n_deadpoints = 20
+        deadpoints = np.random.default_rng(0).standard_normal((n_deadpoints, settings.num_features))
+
+        rd_dir = f"{root}/{settings.child_root}_0"
+        os.makedirs(rd_dir, exist_ok=True)
+        comm.Barrier()
+
+        sim = _make_mock_simulator(settings)
+        resimulate_deadpoints(deadpoints, settings, sim, rd=0)
+
+        comm.Barrier()
+        if comm.Get_rank() == 0:
+            assert os.path.exists(f"{rd_dir}/{settings.targetKey}.npy")
+            assert os.path.exists(f"{rd_dir}/{settings.obsKey}.npy")

--- a/tests/test_mpi_integration.py
+++ b/tests/test_mpi_integration.py
@@ -1,8 +1,8 @@
 """Integration tests for MPI code paths — require mpi4py and mpirun.
 
 Run with:
-    mpirun -n 1 pytest tests/test_mpi_integration.py -v
-    mpirun -n 2 pytest tests/test_mpi_integration.py -v
+    mpirun -n 1 pytest -m integration tests/test_mpi_integration.py -v
+    mpirun -n 2 pytest -m integration tests/test_mpi_integration.py -v
 """
 
 import logging

--- a/tests/test_mpi_unit.py
+++ b/tests/test_mpi_unit.py
@@ -1,0 +1,273 @@
+"""Mock-based unit tests for MPI code paths in polyswyft.
+
+These tests run without mpi4py installed by mocking the MPI module.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import swyft
+
+from polyswyft.settings import PolySwyftSettings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_mock_comm(rank=0, size=1):
+    """Return a MagicMock mimicking MPI.COMM_WORLD with given rank/size."""
+    comm = MagicMock()
+    comm.Get_rank.return_value = rank
+    comm.Get_size.return_value = size
+    comm.Barrier.return_value = None
+    comm.barrier.return_value = None
+    # Default passthrough behaviour (overridden in multi-rank tests)
+    comm.bcast.side_effect = lambda data, root=0: data
+    comm.allgather.side_effect = lambda data: [data]
+    return comm
+
+
+def _make_mock_mpi(comm):
+    """Return mock mpi4py and MPI modules wired to *comm*."""
+    mock_MPI = MagicMock()
+    mock_MPI.COMM_WORLD = comm
+    mock_mpi4py = MagicMock()
+    mock_mpi4py.MPI = mock_MPI
+    return mock_mpi4py, mock_MPI
+
+
+def _make_settings(tmp_path, num_features=2, num_features_dataset=4):
+    """Minimal PolySwyftSettings for MPI tests."""
+    import logging
+
+    settings = PolySwyftSettings(root=str(tmp_path / "mpi_test"))
+    settings.num_features = num_features
+    settings.num_features_dataset = num_features_dataset
+    settings.logger = logging.getLogger("mpi_test")
+    settings.use_noise_resampling = False
+    settings.n_noise_resampling_samples = 3
+    return settings
+
+
+def _make_mock_simulator(settings):
+    """Return a mock simulator whose .sample() returns real swyft.Samples."""
+    d = settings.num_features_dataset
+    rng = np.random.default_rng(42)
+
+    sim = MagicMock()
+
+    def _sample(conditions=None, targets=None):
+        return swyft.Sample(
+            **{
+                settings.targetKey: conditions[settings.targetKey].ravel(),
+                settings.obsKey: rng.standard_normal(d),
+            }
+        )
+
+    sim.sample.side_effect = _sample
+    return sim
+
+
+# ============================================================================
+# resimulate_deadpoints — ImportError
+# ============================================================================
+class TestResimulateDeadpointsImportError:
+    def test_raises_import_error_when_mpi4py_missing(self, tmp_path):
+        settings = _make_settings(tmp_path)
+        deadpoints = np.zeros((5, settings.num_features))
+        sim = MagicMock()
+
+        with patch.dict(sys.modules, {"mpi4py": None, "mpi4py.MPI": None}):
+            from polyswyft.utils import resimulate_deadpoints
+
+            with pytest.raises(ImportError, match="mpi4py"):
+                resimulate_deadpoints(deadpoints, settings, sim, rd=0)
+
+
+# ============================================================================
+# resimulate_deadpoints — single rank (size=1, rank=0)
+# ============================================================================
+class TestResimulateDeadpointsSingleRank:
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        self.settings = _make_settings(tmp_path)
+        self.n_deadpoints = 10
+        self.deadpoints = np.random.default_rng(0).standard_normal(
+            (self.n_deadpoints, self.settings.num_features)
+        )
+        self.sim = _make_mock_simulator(self.settings)
+        self.comm = _make_mock_comm(rank=0, size=1)
+        self.mock_mpi4py, self.mock_MPI = _make_mock_mpi(self.comm)
+
+        # Create round directory
+        rd_dir = f"{self.settings.root}/{self.settings.child_root}_0"
+        os.makedirs(rd_dir, exist_ok=True)
+
+    def _call(self, rd=0):
+        with patch.dict(
+            sys.modules,
+            {"mpi4py": self.mock_mpi4py, "mpi4py.MPI": self.mock_MPI},
+        ):
+            from polyswyft.utils import resimulate_deadpoints
+
+            return resimulate_deadpoints(self.deadpoints, self.settings, self.sim, rd=rd)
+
+    def test_returns_correct_shapes(self):
+        thetas, Ds = self._call()
+        assert thetas.shape == (self.n_deadpoints, self.settings.num_features)
+        assert Ds.shape == (self.n_deadpoints, self.settings.num_features_dataset)
+
+    def test_no_allgather_when_size_one(self):
+        self._call()
+        self.comm.allgather.assert_not_called()
+
+    def test_files_saved_on_rank_zero(self):
+        self._call()
+        rd_dir = f"{self.settings.root}/{self.settings.child_root}_0"
+        assert os.path.exists(f"{rd_dir}/{self.settings.targetKey}.npy")
+        assert os.path.exists(f"{rd_dir}/{self.settings.obsKey}.npy")
+
+    def test_barrier_call_count(self):
+        self._call()
+        total = self.comm.Barrier.call_count + self.comm.barrier.call_count
+        assert total == 4
+
+    def test_bcast_called(self):
+        self._call()
+        assert self.comm.bcast.call_count == 2
+
+
+# ============================================================================
+# resimulate_deadpoints — multi rank (size=2)
+# ============================================================================
+class TestResimulateDeadpointsMultiRank:
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        self.settings = _make_settings(tmp_path)
+        self.n_deadpoints = 10
+        self.deadpoints = np.random.default_rng(0).standard_normal(
+            (self.n_deadpoints, self.settings.num_features)
+        )
+        self.sim = _make_mock_simulator(self.settings)
+
+        # Create round directory
+        rd_dir = f"{self.settings.root}/{self.settings.child_root}_0"
+        os.makedirs(rd_dir, exist_ok=True)
+
+    def _make_comm_and_mpi(self, rank, size=2):
+        comm = _make_mock_comm(rank=rank, size=size)
+
+        # allgather: simulate collecting from all ranks.
+        # In our single-process test we only have the local chunk, so
+        # we duplicate it to mimic two ranks producing data.
+        def _allgather(data):
+            return [data, data]
+
+        comm.allgather.side_effect = _allgather
+        return comm, *_make_mock_mpi(comm)
+
+    def _call(self, rank, rd=0):
+        comm, mock_mpi4py, mock_MPI = self._make_comm_and_mpi(rank)
+        with patch.dict(
+            sys.modules,
+            {"mpi4py": mock_mpi4py, "mpi4py.MPI": mock_MPI},
+        ):
+            from polyswyft.utils import resimulate_deadpoints
+
+            thetas, Ds = resimulate_deadpoints(self.deadpoints, self.settings, self.sim, rd=rd)
+        return thetas, Ds, comm
+
+    def test_allgather_called_when_size_gt_1(self):
+        _, _, comm = self._call(rank=0)
+        comm.allgather.assert_called_once()
+
+    def test_rank_zero_saves_files(self):
+        self._call(rank=0)
+        rd_dir = f"{self.settings.root}/{self.settings.child_root}_0"
+        assert os.path.exists(f"{rd_dir}/{self.settings.targetKey}.npy")
+        assert os.path.exists(f"{rd_dir}/{self.settings.obsKey}.npy")
+
+    def test_non_rank_zero_does_not_save(self):
+        self._call(rank=1)
+        rd_dir = f"{self.settings.root}/{self.settings.child_root}_0"
+        assert not os.path.exists(f"{rd_dir}/{self.settings.targetKey}.npy")
+        assert not os.path.exists(f"{rd_dir}/{self.settings.obsKey}.npy")
+
+    def test_bcast_called_on_all_ranks(self):
+        _, _, comm = self._call(rank=1)
+        assert comm.bcast.call_count == 2
+
+    def test_noise_resampling_path(self):
+        self.settings.use_noise_resampling = True
+        self.settings.n_noise_resampling_samples = 3
+
+        # Setup resampler mock
+        resampler = MagicMock()
+        d = self.settings.num_features_dataset
+        rng = np.random.default_rng(99)
+
+        def _resample(cond):
+            return swyft.Sample(
+                **{
+                    self.settings.targetKey: cond[self.settings.targetKey].ravel(),
+                    self.settings.obsKey: rng.standard_normal(d),
+                }
+            )
+
+        resampler.side_effect = _resample
+        self.sim.get_resampler.return_value = resampler
+
+        # rd > 0 triggers noise resampling
+        rd_dir = f"{self.settings.root}/{self.settings.child_root}_1"
+        os.makedirs(rd_dir, exist_ok=True)
+
+        thetas, Ds, comm = self._call(rank=0, rd=1)
+        # get_resampler called once per deadpoint (5 for rank 0 with size=2)
+        assert self.sim.get_resampler.call_count == 5
+        assert thetas.shape[0] > 0
+
+
+# ============================================================================
+# PolySwyft.__init__ — MPI
+# ============================================================================
+class TestPolySwyftInitMPI:
+    def test_raises_import_error_when_mpi4py_missing(self):
+        with patch.dict(sys.modules, {"mpi4py": None, "mpi4py.MPI": None}):
+            # Need to reload core module so it picks up the patched sys.modules
+            from polyswyft.core import PolySwyft
+
+            with pytest.raises(ImportError, match="mpi4py"):
+                PolySwyft(
+                    polyswyftSettings=MagicMock(),
+                    sim=MagicMock(),
+                    obs=MagicMock(),
+                    deadpoints=np.zeros((5, 2)),
+                    network=MagicMock(),
+                    polyset=MagicMock(),
+                    callbacks=MagicMock(),
+                )
+
+    def test_stores_comm_and_rank(self):
+        comm = _make_mock_comm(rank=3, size=4)
+        mock_mpi4py, mock_MPI = _make_mock_mpi(comm)
+
+        with patch.dict(
+            sys.modules,
+            {"mpi4py": mock_mpi4py, "mpi4py.MPI": mock_MPI},
+        ):
+            from polyswyft.core import PolySwyft
+
+            ps = PolySwyft(
+                polyswyftSettings=MagicMock(),
+                sim=MagicMock(),
+                obs=MagicMock(),
+                deadpoints=np.zeros((5, 2)),
+                network=MagicMock(),
+                polyset=MagicMock(),
+                callbacks=MagicMock(),
+            )
+            assert ps._rank == 3
+            assert ps._comm is comm

--- a/tests/test_mpi_unit.py
+++ b/tests/test_mpi_unit.py
@@ -95,9 +95,7 @@ class TestResimulateDeadpointsSingleRank:
     def setup(self, tmp_path):
         self.settings = _make_settings(tmp_path)
         self.n_deadpoints = 10
-        self.deadpoints = np.random.default_rng(0).standard_normal(
-            (self.n_deadpoints, self.settings.num_features)
-        )
+        self.deadpoints = np.random.default_rng(0).standard_normal((self.n_deadpoints, self.settings.num_features))
         self.sim = _make_mock_simulator(self.settings)
         self.comm = _make_mock_comm(rank=0, size=1)
         self.mock_mpi4py, self.mock_MPI = _make_mock_mpi(self.comm)
@@ -148,9 +146,7 @@ class TestResimulateDeadpointsMultiRank:
     def setup(self, tmp_path):
         self.settings = _make_settings(tmp_path)
         self.n_deadpoints = 10
-        self.deadpoints = np.random.default_rng(0).standard_normal(
-            (self.n_deadpoints, self.settings.num_features)
-        )
+        self.deadpoints = np.random.default_rng(0).standard_normal((self.n_deadpoints, self.settings.num_features))
         self.sim = _make_mock_simulator(self.settings)
 
         # Create round directory

--- a/tests/test_mpi_unit.py
+++ b/tests/test_mpi_unit.py
@@ -130,8 +130,8 @@ class TestResimulateDeadpointsSingleRank:
 
     def test_barrier_call_count(self):
         self._call()
-        total = self.comm.Barrier.call_count + self.comm.barrier.call_count
-        assert total == 4
+        assert self.comm.Barrier.call_count == 4
+        self.comm.barrier.assert_not_called()
 
     def test_bcast_called(self):
         self._call()
@@ -232,7 +232,6 @@ class TestResimulateDeadpointsMultiRank:
 class TestPolySwyftInitMPI:
     def test_raises_import_error_when_mpi4py_missing(self):
         with patch.dict(sys.modules, {"mpi4py": None, "mpi4py.MPI": None}):
-            # Need to reload core module so it picks up the patched sys.modules
             from polyswyft.core import PolySwyft
 
             with pytest.raises(ImportError, match="mpi4py"):


### PR DESCRIPTION
## Summary
- Add 13 mock-based unit tests (`test_mpi_unit.py`) covering MPI code paths in `resimulate_deadpoints` and `PolySwyft.__init__` — runs without mpi4py installed
- Add 3 integration tests (`test_mpi_integration.py`) for real MPI execution via `mpirun -n 1/2`, marked with `@pytest.mark.integration`
- Tests cover: single-rank vs multi-rank paths, rank-0 conditional saves/shuffles, barrier counts, noise resampling, ImportError handling
- `utils.py` coverage increased from ~58% to 76%; total coverage at 65.76%
- Update `CLAUDE.md` with MPI integration test run instructions

## Test plan
- [x] `pytest -m "not integration and not slow" -v` — 132 passed, 2 skipped
- [x] `ruff check .` — all checks passed
- [x] `pytest --cov=polyswyft --cov-report=term-missing` — 65.76% coverage (above 40% threshold)
- [ ] `mpirun -n 1 pytest tests/test_mpi_integration.py -m integration -v` (requires mpi4py)
- [ ] `mpirun -n 2 pytest tests/test_mpi_integration.py -m integration -v` (requires mpi4py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)