### PR TITLE
feat: add PyPI publish workflow and package classifiers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build
+        run: pip install build
+
+      - name: Build distributions
+        run: python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for OIDC trusted publisher
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
## Summary

- Add `.github/workflows/publish.yml` — builds sdist + wheel and publishes to PyPI via OIDC Trusted Publisher on every `v*` tag push (which `version-bump.yml` already creates on merge to master)
- No API token required; uses GitHub OIDC identity against the `pypi` GitHub environment
- Update `pyproject.toml` classifiers: add Python 3.9/3.10/3.11, Apache License, and OS Independent entries

## Test plan

- [x] All 132 unit tests pass (`pytest -m "not integration and not slow" -v`)
- [ ] Merge triggers version bump, new `v*` tag, and `publish.yml` runs
- [ ] Build job produces dist/ artifacts (sdist + wheel)
- [ ] Publish job uploads to PyPI (requires PyPI Trusted Publisher pre-configured)
- [ ] Package visible at https://pypi.org/project/polyswyft/ after first publish

> **Pre-requisite before merging:** configure Trusted Publisher on PyPI (Account > Publishing > Add pending publisher: project `polyswyft`, owner `kilian1103`, repo `PolySwyft`, workflow `publish.yml`, environment `pypi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)