### PR TITLE
fix: split branch and tag push in version-bump to trigger publish workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -96,4 +96,5 @@ jobs:
           git add pyproject.toml polyswyft/__init__.py
           git commit -m "chore: bump version to ${{ steps.new_version.outputs.version }} [skip ci]"
           git tag "v${{ steps.new_version.outputs.version }}"
-          git push origin master --tags
+          git push origin master
+          git push origin "v${{ steps.new_version.outputs.version }}"


### PR DESCRIPTION
## Summary

- Split `git push origin master --tags` into two separate pushes in `version-bump.yml`
- **Root cause:** pushing a branch and tags in a single command only fires the branch push event in GitHub Actions — the tag push event is silently suppressed, so `publish.yml` (which triggers on `push: tags: v*`) never ran
- Separate tag push ensures `publish.yml` is properly triggered after each version bump

## Test plan

- [ ] Merge this PR → version-bump pushes a new `v*` tag as a separate push → `publish.yml` appears in GitHub Actions with a new run
- [ ] `publish.yml` build job completes, publish job enters 10-min wait, then uploads to PyPI after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)