### PR TITLE
fix: platform-specific torch caps for macOS x86_64 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.4.1"
 description = "Sequential simulation-based nested sampling combining PolyChord and swyft"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13"
 authors = [
     { name = "Kilian Scheutwinkel", email = "khs40@cantab.ac.uk" },
 ]
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.24",
     "scipy>=1.11,<1.14",
-    "torch>=2.0",
+    "torch>=2.0,<2.3",
     "pytorch-lightning>=1.9,<2",
     "anesthetic>=2.0",
     "swyft==0.4.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.4.1"
 description = "Sequential simulation-based nested sampling combining PolyChord and swyft"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9"
 authors = [
     { name = "Kilian Scheutwinkel", email = "khs40@cantab.ac.uk" },
 ]
@@ -27,7 +27,8 @@ classifiers = [
 dependencies = [
     "numpy>=1.24",
     "scipy>=1.11,<1.14",
-    "torch>=2.0,<2.3",
+    "torch>=2.0,<2.3; platform_system == 'Darwin' and platform_machine == 'x86_64'",
+    "torch>=2.0; platform_system != 'Darwin' or platform_machine != 'x86_64'",
     "pytorch-lightning>=1.9,<2",
     "anesthetic>=2.0",
     "swyft==0.4.4",


### PR DESCRIPTION
## Summary
- Use PEP 508 environment markers to cap torch<2.3 only on macOS x86_64 (Intel Macs)
- Apple Silicon, Linux, and Windows get torch>=2.0 uncapped
- Remove unnecessary Python<3.13 cap -- only Intel Macs need <=3.12, enforced by torch wheel availability

## Test plan
- [x] uv sync succeeds on macOS x86_64 (Intel Mac) with torch 2.2.x
- [ ] uv sync succeeds on macOS arm64 (Apple Silicon) with latest torch
- [x] pytest -- all 132 tests pass
- [x] ruff check and format -- lint clean