### PR TITLE
ci: add Python 3.12 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     permissions:
       pull-requests: write
@@ -54,7 +54,7 @@ jobs:
             -v
 
       - name: Add coverage to job summary
-        if: always() && matrix.python-version == '3.11'
+        if: always() && matrix.python-version == '3.12'
         run: |
           pip install coverage
           echo "## Coverage Report" >> $GITHUB_STEP_SUMMARY
@@ -63,7 +63,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Coverage comment on PR
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.11'
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.12'
         uses: MishaKav/pytest-coverage-comment@v1.1.58
         with:
           pytest-xml-coverage-path: coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Astronomy",


### PR DESCRIPTION
## Summary
- Add Python 3.12 to the CI test matrix in `.github/workflows/ci.yml`
- Move coverage summary and PR comment steps to run on Python 3.12 (previously 3.11)
- Add `Programming Language :: Python :: 3.12` classifier to `pyproject.toml`

## Test plan
- [ ] CI passes on all matrix versions (3.9, 3.10, 3.11, 3.12)
- [ ] Coverage report appears in job summary for the 3.12 run
- [ ] Coverage comment posts on PR from the 3.12 run

🤖 Generated with [Claude Code](https://claude.com/claude-code)